### PR TITLE
Fixed #11: Writing Azure blob larger than 10MiB fails with 400 Bad Request

### DIFF
--- a/src/Stowage/Impl/Microsoft/AzureBlobFileStorage.cs
+++ b/src/Stowage/Impl/Microsoft/AzureBlobFileStorage.cs
@@ -171,7 +171,7 @@ namespace Stowage.Impl.Microsoft
 
       private HttpRequestMessage CreatePutBlockRequest(int blockId, string containerName, string blobName, byte[] buffer, int count, out string blockIdStr)
       {
-         blockIdStr = Convert.ToBase64String(Encoding.ASCII.GetBytes(blockId.ToString()));
+         blockIdStr = Convert.ToBase64String(Encoding.ASCII.GetBytes(blockId.ToString("d6")));
 
          // call https://docs.microsoft.com/en-us/rest/api/storageservices/put-block
          var request = new HttpRequestMessage(HttpMethod.Put, $"{containerName}/{blobName}?comp=block&blockid={blockIdStr}");


### PR DESCRIPTION
Fixed #11 
I tested the fix.

See https://gauravmantri.com/2013/05/18/windows-azure-blob-storage-dealing-with-the-specified-blob-or-block-content-is-invalid-error/ for details.