### PR TITLE
Added AzureBlobStorageWithSasToken

### DIFF
--- a/src/Stowage.Test/ITestSettings.cs
+++ b/src/Stowage.Test/ITestSettings.cs
@@ -23,6 +23,12 @@ namespace Stowage.Test {
 
         #endregion
 
+        #region [ Azure Sas Token Auth ]
+
+        string AzureStorageSasToken { get; }
+
+        #endregion
+
         string AwsBucket { get; }
 
         string AwsKey { get; }

--- a/src/Stowage.Test/Integration/Impl/AzureBlobTest.cs
+++ b/src/Stowage.Test/Integration/Impl/AzureBlobTest.cs
@@ -60,5 +60,12 @@ namespace Stowage.Test.Integration.Impl {
 
             await storage.Ls();
         }
+
+        [Fact]
+        public async Task Auth_WithSasToken() {
+            IFileStorage storage = Files.Of.AzureBlobStorageWithSasToken(_settings.AzureStorageAccount, _settings.AzureStorageSasToken);
+
+            await storage.Ls("/" +_settings.AzureContainerName + "/");
+        }
     }
 }

--- a/src/Stowage/Files.cs
+++ b/src/Stowage/Files.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
@@ -148,6 +148,28 @@ namespace Stowage {
             const string sharedKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
             var endpoint = new Uri("http://127.0.0.1:10000/devstoreaccount1");
             return new AzureBlobFileStorage(endpoint, new SharedKeyAuthHandler(accountName, sharedKey));
+        }
+
+        /// <summary>
+        /// Create Azure Blob Storage connection with Sas Token authentication.
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="accountName"></param>
+        /// <param name="sasToken"></param>
+        /// <returns></returns>
+        public static IFileStorage AzureBlobStorageWithSasToken(this IFilesFactory _, string accountName, string sasToken) {
+            return new AzureBlobFileStorage(accountName, new SasAuthHandler(sasToken));
+        }
+
+        /// <summary>
+        /// Create Azure Blob Storage connection with Sas Token authentication and custom endpoint.
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="endpoint"></param>
+        /// <param name="sasToken"></param>
+        /// <returns></returns>
+        public static IFileStorage AzureBlobStorageWithSasToken(this IFilesFactory _, Uri endpoint, string sasToken) {
+            return new AzureBlobFileStorage(endpoint, new SasAuthHandler(sasToken));
         }
 
         /// <summary>

--- a/src/Stowage/Impl/Microsoft/SasAuthHandler.cs
+++ b/src/Stowage/Impl/Microsoft/SasAuthHandler.cs
@@ -1,30 +1,44 @@
-﻿using System.Collections.Specialized;
+﻿using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 
 namespace Stowage.Impl.Microsoft {
     class SasAuthHandler : DelegatingHandler {
-        private readonly string _signedStart;
-        private readonly string _signedExpiry;
-        private readonly string _signedResource;
-        private readonly string _signedPermissions;
-
+        private readonly string _sasToken;
 
         /// <summary>
         /// Examples: https://docs.microsoft.com/en-us/rest/api/storageservices/service-sas-examples#blob-examples
         /// </summary>
         /// <param name="sasToken">See https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview#sas-token</param>
-        public SasAuthHandler(string sasToken) {
-            // parse SAS token into parts to sign later
-            NameValueCollection qs = HttpUtility.ParseQueryString(sasToken);
+        public SasAuthHandler(string sasToken) : base(new HttpClientHandler()) {
+            // make sure they didn't include the leading ?, we should strip it
+            if(sasToken.StartsWith('?')) {
+                sasToken = sasToken.Substring(1);
+            }
+
+            _sasToken = sasToken;
         }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
             //?sv=2019-12-12&ss=b&srt=sco&sp=r&se=2021-01-09T19:55:19Z&st=2020-12-07T11:55:19Z&spr=https&sig=ubKzO2g6eWX4pELoKk3XzmptRBi5P34AJj6i42%2Bm5%2FA%3D
 
+            Authenticate(request);
+
             return base.SendAsync(request, cancellationToken);
+        }
+
+#if NET5_0_OR_GREATER
+        protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken) {
+            Authenticate(request);
+
+            return base.Send(request, cancellationToken);
+        }
+#endif
+
+        private void Authenticate(HttpRequestMessage request) {
+            // azure just requires us to append the sasToken to the url, we just need to check if we already have query arguments or not
+            request.RequestUri = new Uri(request.RequestUri + (request.RequestUri.Query.Length > 0 ? "&" : "?") + _sasToken);
         }
     }
 }


### PR DESCRIPTION
Closes #21 

Tried to keep the changes to a minimum, for the test to work you'll need to add the AzureStorageSasToken setting. I'm using the same container to list on, the Ls command will also work on the whole account but that all depends on which allowed resource types you pick when creating the signature.
![image](https://github.com/aloneguid/stowage/assets/2143488/851b5d7f-4a38-4052-aa97-690ea61d54e2)
- Service: will allow Ls()
- Container: will allow Ls("/container/"), that's what the test currently does
- Object: only direct action on blobs (create/read/write/...)  

Since we have the same arguments as the existing AzureBlobStorage I've added a named overload AzureBlobStorageWithSasToken, feel free to change if you had something else in mind.

We might be able to add support inside the BuiltInConnectionFactory as well, for example if we can't find the KeyOrPassword we could check for Token or Sas and then use the new implementation but for me that wasn't needed so it's up to you.

I'm not sure what the first changed line on Files.cs is about, my git editor doesn't show it.