### PR TITLE
Rm oldPath outside of read stream

### DIFF
--- a/src/Stowage/PolyfilledFileStorage.cs
+++ b/src/Stowage/PolyfilledFileStorage.cs
@@ -125,14 +125,18 @@ namespace Stowage {
         }
 
         private async Task RenFile(IOPath oldPath, IOPath newPath, CancellationToken cancellationToken = default) {
+            bool copied = false;
             using(Stream? src = await OpenRead(oldPath, cancellationToken)) {
                 if(src != null) {
                     using(Stream dest = await OpenWrite(newPath, cancellationToken)) {
                         await src.CopyToAsync(dest);
+                        copied = true;
                     }
-
-                    await Rm(oldPath);
                 }
+            }
+
+            if(copied) {
+                await Rm(oldPath); 
             }
         }
 


### PR DESCRIPTION
This commit fixes a bug with trying to remove the oldPath whilst a stream is open for reading and copying it to the newPath; this throws an exception,

This fix moves the removal of the oldPath to happen after the read stream is disposed, and only if it has been copied to the newPath.